### PR TITLE
Add Chrome extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ We have two main goals for the future of Flow Lens:
 +  <actionCalls>
 +    <name>Log_Error2</name>
 +    <label>Log Error</label>
-+    <locationX>440</locationX>
++    <locationX>440</X>
 +    <locationY>458</locationY>
 +    <actionName>Demo</actionName>
 +    <actionType>apex</actionType>
@@ -297,3 +297,29 @@ deno run \
     </td>
   </tr>
 </table>
+
+## Building and Deploying the Chrome Extension
+
+To build and deploy the Chrome extension, follow these steps:
+
+1. **Install dependencies:**
+
+   ```sh
+   npm install
+   ```
+
+2. **Build the extension:**
+
+   ```sh
+   npm run build
+   ```
+
+3. **Load the extension in Chrome:**
+
+   - Open Chrome and navigate to `chrome://extensions/`
+   - Enable "Developer mode" using the toggle switch in the top right corner
+   - Click "Load unpacked" and select the `dist` directory where the extension was built
+
+4. **Test the extension:**
+
+   - The extension should now be loaded in Chrome and ready for testing

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 2,
+  "name": "Flow Lens",
+  "version": "1.0",
+  "description": "A tool to decode Salesforce Flows and visualize them as UML diagrams.",
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"]
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "storage"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "flow-lens",
+  "version": "1.0.0",
+  "description": "A tool to decode Salesforce Flows and visualize them as UML diagrams.",
+  "main": "dist/bundle.js",
+  "scripts": {
+    "build": "webpack"
+  },
+  "dependencies": {
+    "ts-loader": "^9.2.6",
+    "typescript": "^4.5.4",
+    "webpack": "^5.64.4",
+    "webpack-cli": "^4.9.1"
+  },
+  "devDependencies": {
+    "@types/node": "^16.11.7"
+  },
+  "author": "Google LLC",
+  "license": "Apache-2.0"
+}

--- a/src/main/background.ts
+++ b/src/main/background.ts
@@ -1,0 +1,10 @@
+console.log('Background script running...');
+
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Extension installed');
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  console.log('Message received:', message);
+  sendResponse({ status: 'Message received' });
+});

--- a/src/main/content.ts
+++ b/src/main/content.ts
@@ -1,0 +1,6 @@
+console.log('Content script running...');
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  console.log('Message received in content script:', message);
+  sendResponse({ status: 'Message received in content script' });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/main/main.ts',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  resolve: {
+    extensions: ['.ts', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  mode: 'production',
+};


### PR DESCRIPTION
Add configuration for bundling TypeScript code to JavaScript and setting up a Chrome extension.

* **Webpack Configuration:**
  - Add `webpack.config.js` to configure Webpack for bundling TypeScript code.
  - Set entry point to `src/main/main.ts` and output directory to `dist`.
  - Use `ts-loader` for handling TypeScript files and set mode to `production`.

* **Chrome Extension Manifest:**
  - Add `manifest.json` to configure the Chrome extension.
  - Define background script as `background.js` and content script as `content.js`.
  - Set necessary permissions for the extension.

* **Build and Deployment Instructions:**
  - Update `README.md` with instructions for building and deploying the Chrome extension.
  - Include steps for installing dependencies, building the extension, and loading it in Chrome.

* **Package Configuration:**
  - Add `package.json` with necessary dependencies and build scripts.

* **Background and Content Scripts:**
  - Add `src/main/background.ts` for background script functionality.
  - Add `src/main/content.ts` for content script functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kagawa-furucrm/flow_lens/pull/1?shareId=b8959777-2bc7-4db3-a495-d2026132a8d0).